### PR TITLE
Add GPSと標高による表示内容の補正

### DIFF
--- a/app/_components/CameraPosition.tsx
+++ b/app/_components/CameraPosition.tsx
@@ -11,7 +11,6 @@ export const CameraPosition: React.FC<Props> = ({ point }) => {
   const { camera } = useThree();
   useEffect(() => {
     camera.position.set(point.x, point.y, point.z);
-    console.log('camera position', camera.position);
   }, [point, camera.position]);
   return <></>;
 };

--- a/app/_components/CameraPosition.tsx
+++ b/app/_components/CameraPosition.tsx
@@ -1,4 +1,4 @@
-'use clent';
+'use client';
 import { useThree } from '@react-three/fiber';
 import React, { useEffect } from 'react';
 import { Vector3 } from 'three';

--- a/app/_components/Canavs.tsx
+++ b/app/_components/Canavs.tsx
@@ -2,7 +2,6 @@
 import { XR } from '@react-three/xr';
 import React, { useEffect, useState } from 'react';
 import { Vector3 } from 'three';
-import { BoxComponent } from './Box';
 import { TriangleComponent } from './Triangle';
 
 type Props = {
@@ -28,9 +27,6 @@ export const CanvasComponent: React.FC<Props> = ({ points }) => {
         <ambientLight />
         {polygonVertices.map((vertices, index) => (
           <TriangleComponent key={index} vertices={vertices} />
-        ))}
-        {polygonVertices.map((vertices, index) => (
-          <BoxComponent key={index} position={vertices[0]} />
         ))}
       </XR>
     </>

--- a/app/_components/Canavs.tsx
+++ b/app/_components/Canavs.tsx
@@ -10,7 +10,6 @@ type Props = {
 };
 
 export const CanvasComponent: React.FC<Props> = ({ points }) => {
-  //   console.log(points);
   const [polygonVertices, setPolygonVertices] = useState<Vector3[][]>([]);
 
   useEffect(() => {

--- a/app/_components/InputBox..tsx
+++ b/app/_components/InputBox..tsx
@@ -1,0 +1,20 @@
+import React, { SetStateAction, useState } from 'react';
+import GPSLocation from '../_types/GPSLocation';
+
+type Props = {
+  // eslint-disable-next-line no-unused-vars
+  setGPS: (value: SetStateAction<GPSLocation>) => void;
+};
+
+export const InputBox: React.FC<Props> = ({ setGPS }) => {
+  const [lat, setLat] = useState('');
+  const [lon, setLon] = useState('');
+
+  return (
+    <>
+      <input type='text' value={lat} onChange={(event) => setLat(event.target.value)} />
+      <input type='text' value={lon} onChange={(event) => setLon(event.target.value)} />
+      <button onClick={() => setGPS({ lat: Number(lat), lon: Number(lon) })}>決定</button>
+    </>
+  );
+};

--- a/app/_components/ThreeCamera.tsx
+++ b/app/_components/ThreeCamera.tsx
@@ -91,5 +91,5 @@ export const ThreeCamera: React.FC<ThreeCameraProps> = ({ cameraPosition, setCam
     setCameraPosition(camera.position);
   });
 
-  return <PerspectiveCamera fov={90} makeDefault position={cameraPosition} near={1} far={1000} />;
+  return <PerspectiveCamera fov={90} makeDefault position={cameraPosition} near={1} far={200} />;
 };

--- a/app/_components/ThreeCamera.tsx
+++ b/app/_components/ThreeCamera.tsx
@@ -87,7 +87,7 @@ export const ThreeCamera: React.FC<ThreeCameraProps> = ({ cameraPosition, setCam
   );
 
   useFrame(({ camera }) => {
-    moveCamera(camera, 0.5, 0.1);
+    moveCamera(camera, 2, 0.1);
     setCameraPosition(camera.position);
   });
 

--- a/app/_components/Triangle.tsx
+++ b/app/_components/Triangle.tsx
@@ -8,7 +8,6 @@ type Props = {
 
 export const TriangleComponent: React.FC<Props> = ({ vertices }) => {
   const geometry = new THREE.BufferGeometry().setFromPoints(vertices);
-  console.log(geometry);
 
   return (
     <mesh geometry={geometry}>

--- a/app/_components/Triangle.tsx
+++ b/app/_components/Triangle.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export const TriangleComponent: React.FC<Props> = ({ vertices }) => {
   const geometry = new THREE.BufferGeometry().setFromPoints(vertices);
-  
+
   return (
     <mesh geometry={geometry}>
       <meshBasicMaterial color={'blue'} wireframe={false} side={THREE.DoubleSide} />

--- a/app/_components/Triangle.tsx
+++ b/app/_components/Triangle.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export const TriangleComponent: React.FC<Props> = ({ vertices }) => {
   const geometry = new THREE.BufferGeometry().setFromPoints(vertices);
-
+  
   return (
     <mesh geometry={geometry}>
       <meshBasicMaterial color={'blue'} wireframe={false} side={THREE.DoubleSide} />

--- a/app/_types/GPSLocation.ts
+++ b/app/_types/GPSLocation.ts
@@ -1,0 +1,6 @@
+type GPSLocation = {
+  lat: number;
+  lon: number;
+};
+
+export default GPSLocation;

--- a/app/_utils/latLonToMeters.ts
+++ b/app/_utils/latLonToMeters.ts
@@ -1,0 +1,11 @@
+import { MathUtils } from 'three';
+
+// Function to convert lat lon to meters
+export function latLonToMeters(lat: number, lon: number) {
+  const earthRadius = 6378137;
+  const dLat = MathUtils.degToRad(lat);
+  const dLon = MathUtils.degToRad(lon);
+  const x = earthRadius * dLon;
+  const y = earthRadius * Math.log(Math.tan(Math.PI * 0.25 + 0.5 * dLat));
+  return { x, y };
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,31 +3,45 @@ import { Canvas } from '@react-three/fiber';
 import { EffectComposer, SSAO } from '@react-three/postprocessing';
 import { ARButton } from '@react-three/xr';
 import { useEffect, useState } from 'react';
-import { MathUtils, Vector3 } from 'three';
+import { Vector3 } from 'three';
 import { CameraPosition } from './_components/CameraPosition';
 import { CanvasComponent } from './_components/Canavs';
 import { ThreeCamera } from './_components/ThreeCamera';
 import { BuildingData, DefaultLocation } from './_types/Building';
+import { latLonToMeters } from './_utils/latLonToMeters';
 
-// Function to convert lat lon to meters
-function latLonToMeters(lat: number, lon: number) {
-  const earthRadius = 6378137;
-  const dLat = MathUtils.degToRad(lat);
-  const dLon = MathUtils.degToRad(lon);
-  const x = earthRadius * dLon;
-  const y = earthRadius * Math.log(Math.tan(Math.PI * 0.25 + 0.5 * dLat));
-  return { x, y };
-}
+type GPSLocation = {
+  lat: number;
+  lon: number;
+};
 
 export default function Home() {
   const [cameraPosition, setCameraPosition] = useState<Vector3>(new Vector3(0, 0, 0));
   const path = process.env.NEXT_PUBLIC_BUILDING_DATA_URL;
   const [buildingDatas, setBuildingDatas] = useState<BuildingData[]>([]);
-  const [buildingCentroid, setBuildingCentroid] = useState<Vector3>(new Vector3(0, 0, 0));
+  const [bias, setBias] = useState<Vector3>(new Vector3(0, 0, 0));
+
+  const [gps, setGPS] = useState<GPSLocation>({ lat: 0, lon: 0 });
 
   useEffect(() => {
-    setBuildingCentroid(new Vector3(15237312, 4186921.75, 3.10448294878006));
+    const watchId = navigator.geolocation.watchPosition((position) => {
+      setGPS({ lat: position.coords.latitude, lon: position.coords.longitude });
+    });
+
+    // Cleanup function to stop watching the GPS when the component unmounts
+    return () => navigator.geolocation.clearWatch(watchId);
+  }, []);
+
+  useEffect(() => {
+    console.log(buildingDatas);
   }, [buildingDatas]);
+
+  useEffect(() => {
+    // const { x, y } = latLonToMeters(gps.lat, gps.lon);
+    const x = 15237835.6572;
+    const y = 41866502.62523;
+    setBias(new Vector3(x, y, 0));
+  }, [gps]);
 
   useEffect(() => {
     fetch(`${path}`)
@@ -56,10 +70,13 @@ export default function Home() {
       <ARButton />
       <Canvas style={{ width: '100vw', height: '100vh' }}>
         <ThreeCamera cameraPosition={cameraPosition} setCameraPosition={setCameraPosition} />
-        <CameraPosition point={buildingCentroid} />
-        {buildingDatas.map((buildingData) => (
-          <CanvasComponent key={buildingData.id} points={buildingData.locations} />
-        ))}
+        <CameraPosition point={new Vector3(0, 0, 0)} />
+        {buildingDatas.map((buildingData) => {
+          const points = buildingData.locations.map((location) => {
+            return new Vector3(location.x - bias.x, location.y - bias.y, location.z - bias.z);
+          });
+          return <CanvasComponent key={buildingData.id} points={points} />;
+        })}
         <EffectComposer>
           <SSAO />
         </EffectComposer>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,11 +6,14 @@ import { useEffect, useState } from 'react';
 import { Vector3 } from 'three';
 import { CameraPosition } from './_components/CameraPosition';
 import { CanvasComponent } from './_components/Canavs';
-import { InputBox } from './_components/InputBox.';
 import { ThreeCamera } from './_components/ThreeCamera';
 import { BuildingData, DefaultLocation } from './_types/Building';
-import GPSLocation from './_types/GPSLocation';
 import { latLonToMeters } from './_utils/latLonToMeters';
+
+type GPSLocation = {
+  lat: number;
+  lon: number;
+};
 
 export default function Home() {
   const [cameraPosition, setCameraPosition] = useState<Vector3>(new Vector3(0, 0, 0));
@@ -20,18 +23,18 @@ export default function Home() {
 
   const [gps, setGPS] = useState<GPSLocation>({ lat: 0, lon: 0 });
 
-  // useEffect(() => {
-  //   const watchId = navigator.geolocation.watchPosition((position) => {
-  //     setGPS({ lat: position.coords.latitude, lon: position.coords.longitude });
-  //   });
+  useEffect(() => {
+    const watchId = navigator.geolocation.watchPosition((position) => {
+      setGPS({ lat: position.coords.latitude, lon: position.coords.longitude });
+    });
 
-  //   // Cleanup function to stop watching the GPS when the component unmounts
-  //   return () => navigator.geolocation.clearWatch(watchId);
-  // }, []);
+    // Cleanup function to stop watching the GPS when the component unmounts
+    return () => navigator.geolocation.clearWatch(watchId);
+  }, []);
 
   useEffect(() => {
-    const { x, y } = latLonToMeters(gps.lat, gps.lon);
-    // const { x, y } = latLonToMeters(35.1705901, 136.8798116);
+    // const { x, y } = latLonToMeters(gps.lat, gps.lon);
+    const { x, y } = latLonToMeters(35.1705901,136.8798116);
     setBias(new Vector3(x, y, 0));
   }, [gps]);
 
@@ -59,7 +62,6 @@ export default function Home() {
   }, [path, setBuildingDatas]);
   return (
     <>
-      <InputBox setGPS={setGPS} />
       <ARButton />
       <Canvas style={{ width: '100vw', height: '100vh' }}>
         <ThreeCamera cameraPosition={cameraPosition} setCameraPosition={setCameraPosition} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,13 +33,9 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    console.log(buildingDatas);
-  }, [buildingDatas]);
-
-  useEffect(() => {
     // const { x, y } = latLonToMeters(gps.lat, gps.lon);
-    const x = 15237835.6572;
-    const y = 41866502.62523;
+    const x = 15237635.6572;
+    const y = 4186802.62523;
     setBias(new Vector3(x, y, 0));
   }, [gps]);
 
@@ -70,10 +66,10 @@ export default function Home() {
       <ARButton />
       <Canvas style={{ width: '100vw', height: '100vh' }}>
         <ThreeCamera cameraPosition={cameraPosition} setCameraPosition={setCameraPosition} />
-        <CameraPosition point={new Vector3(0, 0, 0)} />
+        <CameraPosition point={new Vector3(0, 2, 0)} />
         {buildingDatas.map((buildingData) => {
           const points = buildingData.locations.map((location) => {
-            return new Vector3(location.x - bias.x, location.y - bias.y, location.z - bias.z);
+            return new Vector3(location.x - bias.x, location.z - bias.z, location.y - bias.y);
           });
           return <CanvasComponent key={buildingData.id} points={points} />;
         })}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,8 +35,8 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    const { x, y } = latLonToMeters(gps.lat, gps.lon);
     if (!gps.lat || !gps.lon) return;
+    const { x, y } = latLonToMeters(gps.lat, gps.lon);
     const elevationUrl = `https://cyberjapandata2.gsi.go.jp/general/dem/scripts/getelevation.php?lon=${gps.lon}&lat=${gps.lat}&outtype=JSON`;
     fetch(elevationUrl)
       .then((response) => response.json())

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,6 +36,7 @@ export default function Home() {
 
   useEffect(() => {
     const { x, y } = latLonToMeters(gps.lat, gps.lon);
+    if (!gps.lat || !gps.lon) return;
     const elevationUrl = `https://cyberjapandata2.gsi.go.jp/general/dem/scripts/getelevation.php?lon=${gps.lon}&lat=${gps.lat}&outtype=JSON`;
     fetch(elevationUrl)
       .then((response) => response.json())

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,8 +17,12 @@ type GPSLocation = {
 
 export default function Home() {
   const [cameraPosition, setCameraPosition] = useState<Vector3>(new Vector3(0, 0, 0));
-  const path = process.env.NEXT_PUBLIC_BUILDING_DATA_URL;
-  const [buildingDatas, setBuildingDatas] = useState<BuildingData[]>([]);
+  // const path = process.env.NEXT_PUBLIC_BUILDING_DATA_URL_23;
+  const path23 = process.env.NEXT_PUBLIC_BUILDING_DATA_URL_23;
+  const path24 = process.env.NEXT_PUBLIC_BUILDING_DATA_URL_24;
+  // const [cityDatas, setCityDatas] = useState<BuildingData[]>([]);
+  const [cityDatas23, setCityDatas23] = useState<BuildingData[]>([]);
+  const [cityDatas24, setCityDatas24] = useState<BuildingData[]>([]);
   const [bias, setBias] = useState<Vector3>(new Vector3(0, 0, 0));
 
   const [gps, setGPS] = useState<GPSLocation>({ lat: 0, lon: 0 });
@@ -34,22 +38,24 @@ export default function Home() {
 
   useEffect(() => {
     // const { x, y } = latLonToMeters(gps.lat, gps.lon);
-    const { x, y } = latLonToMeters(35.1705901,136.8798116);
+    const { x, y } = latLonToMeters(35.18444, 136.924762);
     setBias(new Vector3(x, y, 0));
   }, [gps]);
 
   useEffect(() => {
-    fetch(`${path}`)
+    fetch(`${path23}`)
       .then((response) => response.json())
       .then((data: any[]) => {
         let buildingDatas: BuildingData[] = [];
         data.forEach((d) => {
           let locations: Vector3[] = [];
           d.location.forEach((l: DefaultLocation) => {
-            const { x, y } = latLonToMeters(+l.lat, +l.lon);
-            const { height } = l;
-            const location: Vector3 = new Vector3(x, y, height);
-            locations.push(location);
+            if (l.lat <= 35.1875 && l.lat >= 35.18) {
+              const { x, y } = latLonToMeters(+l.lat, +l.lon);
+              const { height } = l;
+              const location: Vector3 = new Vector3(x, y, height);
+              locations.push(location);
+            }
           });
           const buildingData: BuildingData = {
             id: d.id,
@@ -57,20 +63,54 @@ export default function Home() {
           };
           buildingDatas.push(buildingData);
         });
-        setBuildingDatas(buildingDatas);
+        setCityDatas23(buildingDatas);
       });
-  }, [path, setBuildingDatas]);
+  }, [path23, setCityDatas23]);
+
+  useEffect(() => {
+    fetch(`${path24}`)
+      .then((response) => response.json())
+      .then((data: any[]) => {
+        let buildingDatas: BuildingData[] = [];
+        data.forEach((d) => {
+          let locations: Vector3[] = [];
+          d.location.forEach((l: DefaultLocation) => {
+            if (l.lat <= 35.1875 && l.lat >= 35.18) {
+              const { x, y } = latLonToMeters(+l.lat, +l.lon);
+              const { height } = l;
+              const location: Vector3 = new Vector3(x, y, height);
+              locations.push(location);
+            }
+          });
+          const buildingData: BuildingData = {
+            id: d.id,
+            locations: locations,
+          };
+          buildingDatas.push(buildingData);
+        });
+        setCityDatas24(buildingDatas);
+      });
+  }, [path24, setCityDatas24]);
+
   return (
     <>
       <ARButton />
       <Canvas style={{ width: '100vw', height: '100vh' }}>
         <ThreeCamera cameraPosition={cameraPosition} setCameraPosition={setCameraPosition} />
-        <CameraPosition point={new Vector3(0, 2, 0)} />
-        {buildingDatas.map((buildingData) => {
-          const points = buildingData.locations.map((location) => {
+        <CameraPosition point={new Vector3(0, 16, 0)} />
+        {cityDatas23.map((cityData) => {
+          const points = cityData.locations.map((location) => {
             return new Vector3(location.x - bias.x, location.z - bias.z, -(location.y - bias.y));
           });
-          return <CanvasComponent key={buildingData.id} points={points} />;
+          console.log(points);
+          return <CanvasComponent key={cityData.id} points={points} />;
+        })}
+        {cityDatas24.map((cityData) => {
+          const points = cityData.locations.map((location) => {
+            return new Vector3(location.x - bias.x, location.z - bias.z, -(location.y - bias.y));
+          });
+          console.log(points);
+          return <CanvasComponent key={cityData.id} points={points} />;
         })}
         <EffectComposer>
           <SSAO />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,8 +36,16 @@ export default function Home() {
 
   useEffect(() => {
     const { x, y } = latLonToMeters(gps.lat, gps.lon);
-    // const { x, y } = latLonToMeters(35.18444, 136.924762);
-    setBias(new Vector3(x, y, 20));
+    const elevationUrl = `https://cyberjapandata2.gsi.go.jp/general/dem/scripts/getelevation.php?lon=${gps.lon}&lat=${gps.lat}&outtype=JSON`;
+    fetch(elevationUrl)
+      .then((response) => response.json())
+      .then((data) => {
+        setBias(new Vector3(x, y, data.elevation));
+      })
+      .catch((error: Error) => {
+        console.error('Error:', error);
+        setBias(new Vector3(x, y, 0));
+      });
   }, [gps]);
 
   useEffect(() => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,14 +6,11 @@ import { useEffect, useState } from 'react';
 import { Vector3 } from 'three';
 import { CameraPosition } from './_components/CameraPosition';
 import { CanvasComponent } from './_components/Canavs';
+import { InputBox } from './_components/InputBox.';
 import { ThreeCamera } from './_components/ThreeCamera';
 import { BuildingData, DefaultLocation } from './_types/Building';
+import GPSLocation from './_types/GPSLocation';
 import { latLonToMeters } from './_utils/latLonToMeters';
-
-type GPSLocation = {
-  lat: number;
-  lon: number;
-};
 
 export default function Home() {
   const [cameraPosition, setCameraPosition] = useState<Vector3>(new Vector3(0, 0, 0));
@@ -23,18 +20,18 @@ export default function Home() {
 
   const [gps, setGPS] = useState<GPSLocation>({ lat: 0, lon: 0 });
 
-  useEffect(() => {
-    const watchId = navigator.geolocation.watchPosition((position) => {
-      setGPS({ lat: position.coords.latitude, lon: position.coords.longitude });
-    });
+  // useEffect(() => {
+  //   const watchId = navigator.geolocation.watchPosition((position) => {
+  //     setGPS({ lat: position.coords.latitude, lon: position.coords.longitude });
+  //   });
 
-    // Cleanup function to stop watching the GPS when the component unmounts
-    return () => navigator.geolocation.clearWatch(watchId);
-  }, []);
+  //   // Cleanup function to stop watching the GPS when the component unmounts
+  //   return () => navigator.geolocation.clearWatch(watchId);
+  // }, []);
 
   useEffect(() => {
-    // const { x, y } = latLonToMeters(gps.lat, gps.lon);
-    const { x, y } = latLonToMeters(35.1705901,136.8798116);
+    const { x, y } = latLonToMeters(gps.lat, gps.lon);
+    // const { x, y } = latLonToMeters(35.1705901, 136.8798116);
     setBias(new Vector3(x, y, 0));
   }, [gps]);
 
@@ -62,6 +59,7 @@ export default function Home() {
   }, [path, setBuildingDatas]);
   return (
     <>
+      <InputBox setGPS={setGPS} />
       <ARButton />
       <Canvas style={{ width: '100vw', height: '100vh' }}>
         <ThreeCamera cameraPosition={cameraPosition} setCameraPosition={setCameraPosition} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,8 +35,8 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    // const { x, y } = latLonToMeters(gps.lat, gps.lon);
-    const { x, y } = latLonToMeters(35.18444, 136.924762);
+    const { x, y } = latLonToMeters(gps.lat, gps.lon);
+    // const { x, y } = latLonToMeters(35.18444, 136.924762);
     setBias(new Vector3(x, y, 20));
   }, [gps]);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,8 +34,7 @@ export default function Home() {
 
   useEffect(() => {
     // const { x, y } = latLonToMeters(gps.lat, gps.lon);
-    const x = 15237635.6572;
-    const y = 4186802.62523;
+    const { x, y } = latLonToMeters(35.1705901,136.8798116);
     setBias(new Vector3(x, y, 0));
   }, [gps]);
 
@@ -69,7 +68,7 @@ export default function Home() {
         <CameraPosition point={new Vector3(0, 2, 0)} />
         {buildingDatas.map((buildingData) => {
           const points = buildingData.locations.map((location) => {
-            return new Vector3(location.x - bias.x, location.z - bias.z, location.y - bias.y);
+            return new Vector3(location.x - bias.x, location.z - bias.z, -(location.y - bias.y));
           });
           return <CanvasComponent key={buildingData.id} points={points} />;
         })}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,7 @@ export default function Home() {
   const [bias, setBias] = useState<Vector3>(new Vector3(0, 0, 0));
 
   const [gps, setGPS] = useState<GPSLocation>({ lat: 0, lon: 0 });
+  const humanHeight = 1.6;
 
   useEffect(() => {
     const watchId = navigator.geolocation.watchPosition((position) => {
@@ -41,7 +42,7 @@ export default function Home() {
     fetch(elevationUrl)
       .then((response) => response.json())
       .then((data) => {
-        setBias(new Vector3(x, y, data.elevation));
+        setBias(new Vector3(x, y, data.elevation+humanHeight));
       })
       .catch((error: Error) => {
         console.error('Error:', error);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,10 +17,8 @@ type GPSLocation = {
 
 export default function Home() {
   const [cameraPosition, setCameraPosition] = useState<Vector3>(new Vector3(0, 0, 0));
-  // const path = process.env.NEXT_PUBLIC_BUILDING_DATA_URL_23;
   const path23 = process.env.NEXT_PUBLIC_BUILDING_DATA_URL_23;
   const path24 = process.env.NEXT_PUBLIC_BUILDING_DATA_URL_24;
-  // const [cityDatas, setCityDatas] = useState<BuildingData[]>([]);
   const [cityDatas23, setCityDatas23] = useState<BuildingData[]>([]);
   const [cityDatas24, setCityDatas24] = useState<BuildingData[]>([]);
   const [bias, setBias] = useState<Vector3>(new Vector3(0, 0, 0));
@@ -39,7 +37,7 @@ export default function Home() {
   useEffect(() => {
     // const { x, y } = latLonToMeters(gps.lat, gps.lon);
     const { x, y } = latLonToMeters(35.18444, 136.924762);
-    setBias(new Vector3(x, y, 0));
+    setBias(new Vector3(x, y, 20));
   }, [gps]);
 
   useEffect(() => {
@@ -102,14 +100,14 @@ export default function Home() {
           const points = cityData.locations.map((location) => {
             return new Vector3(location.x - bias.x, location.z - bias.z, -(location.y - bias.y));
           });
-          console.log(points);
+          if (points.length === 0) return;
           return <CanvasComponent key={cityData.id} points={points} />;
         })}
         {cityDatas24.map((cityData) => {
           const points = cityData.locations.map((location) => {
             return new Vector3(location.x - bias.x, location.z - bias.z, -(location.y - bias.y));
           });
-          console.log(points);
+          if (points.length === 0) return;
           return <CanvasComponent key={cityData.id} points={points} />;
         })}
         <EffectComposer>


### PR DESCRIPTION
## やったこと
- 建物の輪郭の描画
  - JSON によるそれぞれの建物の頂点情報の取得
  - 建物ごとに取得した頂点による任意の多角形をthree.jsを用いて描画
- 視野角とカメラの描画距離の設定
- GPS によるユーザー座標の再設定
  - GPS のメートルへの変換
  - フックとして GPS から建物情報をユーザー地点に合わせてシフトさせる
- 描画対象の設定
  - 描画対象を2つの区画分に設定
  - 軽量化のため不要な区画のレンダリングをやめる

## やっていないこと
- WebAR を起動した状態でのインタラクティブな操作
- 方位に基づく初期方向の決定